### PR TITLE
Do not attempt to match newlines

### DIFF
--- a/grammars/csound-document.cson
+++ b/grammars/csound-document.cson
@@ -81,7 +81,7 @@ patterns: [
       {
         name:  "comment.line.cabbage-gui.csound-document"
         begin: ";"
-        end:   "(?=\\n)"
+        end:   "$"
         beginCaptures: 0: name: "punctuation.definition.comment.line.cabbage-gui.csound-document"
       }
       {include: "source.csound#macroUses"}

--- a/grammars/csound-score.cson
+++ b/grammars/csound-score.cson
@@ -28,7 +28,7 @@ patterns: [
       2: name: "constant.numeric.integer.decimal.csound-score"
   },{
     begin: "(m)|(n)"
-    end:   "\\n"
+    end:   "$"
     beginCaptures:
       1: name: "keyword.mark.preprocessor.csound-score"
       2: name: "keyword.repeat-mark.preprocessor.csound-score"
@@ -41,13 +41,13 @@ patterns: [
     ]
   },{
     begin: "r\\b"
-    end:   "\\n"
+    end:   "$"
     beginCaptures: 0: name: "keyword.repeat-section.preprocessor.csound-score"
     patterns: [
       {include: "source.csound#comments"}
       {
         begin: "\\d+"
-        end:   "(?=\\n)"
+        end:   "(?=$)"
         beginCaptures: 0: name: "constant.numeric.integer.decimal.csound-score"
         patterns: [
           {include: "source.csound#comments"}
@@ -77,16 +77,16 @@ patterns: [
       {
         name: "meta.braced-loop-details.csound-score"
         begin: "\\G"
-        end:   "(?=\\n)"
+        end:   "$"
         patterns: [
           {
             begin: "\\d+"
-            end:   "(?=\\n)"
+            end:   "$"
             beginCaptures: 0: name: "constant.numeric.integer.decimal.csound-score"
             patterns: [
               {
                 begin: "[A-Z_a-z]\\w*\\b"
-                end:   "(?=\\n)"
+                end:   "$"
                 beginCaptures: 0: name: "entity.name.function.preprocessor.csound-score"
                 patterns: [
                   {include: "#comments"}
@@ -110,7 +110,7 @@ patterns: [
           }
         ]
       },{
-        begin: "\\n"
+        begin: "^"
         end:   "(?=\\})"
         patterns: [include: "$self"]
       }

--- a/grammars/csound.cson
+++ b/grammars/csound.cson
@@ -13,7 +13,7 @@ patterns: [
       {
         name:  "meta.instrument-declaration.csound"
         begin: "instr"
-        end:   "\\n"
+        end:   "$"
         beginCaptures: 0: name: "keyword.function.csound"
         patterns: [
           {
@@ -36,20 +36,20 @@ patterns: [
       {
         name:  "meta.opcode-declaration.csound"
         begin: "opcode"
-        end:   "\\n"
+        end:   "$"
         beginCaptures: 0: name: "keyword.function.csound"
         patterns: [
           {
             name:  "meta.opcode-details.csound"
             begin: "[A-Z_a-z]\\w*\\b"
-            end:   "(?=\\n)"
+            end:   "$"
             beginCaptures: 0: name: "entity.name.function.opcode.csound"
             patterns: [
               {
                 name:  "meta.opcode-type-signature.csound"
                 # https://github.com/csound/csound/search?q=XIDENT+path%3AEngine+filename%3Acsound_orc.lex
                 begin: "\\b(?:0|[afijkKoOpPStV\\[\\]]+)"
-                end:   ",|(?=\\n)"
+                end:   ",|$"
                 beginCaptures: 0: name: "storage.type.csound"
                 patterns: [include: "#commentsAndMacroUses"]
               }
@@ -86,7 +86,7 @@ repository:
       },{
         name:  "comment.line.double-slash.csound"
         begin: "//"
-        end:   "(?=\\n)"
+        end:   "$"
         beginCaptures: 0: name: "punctuation.definition.comment.csound"
       }
       {include: "#semicolonComments"}
@@ -97,7 +97,7 @@ repository:
       {
         name:  "comment.line.semicolon.csound"
         begin: ";"
-        end:   "(?=\\n)"
+        end:   "$"
         beginCaptures: 0: name: "punctuation.definition.comment.csound"
       }
     ]
@@ -173,7 +173,7 @@ repository:
   lineContinuations:
     patterns: [
       {
-        match: "(\\\\)[ \\t]*((;).*)?\\n"
+        match: "(\\\\)[ \\t]*((;).*)?$"
         captures:
           1: name: "constant.character.escape.line-continuation.csound"
           2: name: "comment.line.semicolon.csound"
@@ -293,7 +293,7 @@ repository:
         match: "\\b(?:do|else(?:if)?|end(?:if|until)|fi|i(?:f|then)|kthen|od|r(?:ir)?eturn|then|until|while)\\b"
       },{
         begin: "\\b((?:c(?:g|in?|k|nk?)goto)|goto|igoto|kgoto|loop_[gl][et]|r(?:einit|igoto)|ti(?:goto|mout))\\b"
-        end:   "(\\w+)\\s*(?:((//).*)|((;).*))?\\n"
+        end:   "(\\w+)\\s*(?:((//).*)|((;).*))?$"
         beginCaptures:
           1: name: "keyword.control.csound"
         endCaptures:
@@ -330,7 +330,7 @@ repository:
                 match: "%[!nNrRtT]|[~^]{1,2}"
               },{
                 name:  "invalid.illegal.csound"
-                match: '[^"\\\\\\n]*\\n'
+                match: '[^"\\\\]*[^\\n"\\\\]$'
               }
             ]
           }
@@ -408,7 +408,7 @@ repository:
         match: "\\#(?:e(?:lse|nd(?:if)?)\\b|\\#\\#)|@+[ \\t]*\\d*"
       },{
         begin: "\\#include"
-        end:   "\\n"
+        end:   "$"
         beginCaptures: 0: name: "keyword.include.preprocessor.csound"
         patterns: [
           {include: "#commentsAndMacroUses"}
@@ -452,7 +452,7 @@ repository:
         ]
       },{
         begin: "\\#(?:i(?:fn?def)|undef)"
-        end:   "\\n"
+        end:   "$"
         beginCaptures: 0: name: "keyword.preprocessor.csound"
         patterns: [
           {include: "#commentsAndMacroUses"}
@@ -468,7 +468,7 @@ repository:
       {include: "#lineContinuations"}
       {
         name:  "invalid.illegal.csound"
-        match: '[^"\\\\\\n]*\\n'
+        match: '[^"\\\\]*[^\\n"\\\\]$'
       }
     ]
 

--- a/spec/language-csound-spec.coffee
+++ b/spec/language-csound-spec.coffee
@@ -48,7 +48,7 @@ describe "language-csound", ->
       """
 
       tokens = lines[0]
-      expect(tokens.length).toBe 15
+      expect(tokens.length).toBe 14
       expect(tokens[0]).toEqual value: "instr", scopes: ["source.csound", "meta.instrument-block.csound", "meta.instrument-declaration.csound", "keyword.function.csound"]
       expect(tokens[1]).toEqual value: "/*", scopes: ["source.csound", "meta.instrument-block.csound", "meta.instrument-declaration.csound", "comment.block.csound", "punctuation.definition.comment.begin.csound"]
       expect(tokens[2]).toEqual value: "*/", scopes: ["source.csound", "meta.instrument-block.csound", "meta.instrument-declaration.csound", "comment.block.csound", "punctuation.definition.comment.end.csound"]
@@ -63,7 +63,6 @@ describe "language-csound", ->
       expect(tokens[11]).toEqual value: "+", scopes: ["source.csound", "meta.instrument-block.csound", "meta.instrument-declaration.csound"]
       expect(tokens[12]).toEqual value: "Name", scopes: ["source.csound", "meta.instrument-block.csound", "meta.instrument-declaration.csound", "entity.name.function.csound"]
       expect(tokens[13]).toEqual value: "//", scopes: ["source.csound", "meta.instrument-block.csound", "meta.instrument-declaration.csound", "comment.line.double-slash.csound", "punctuation.definition.comment.csound"]
-      expect(tokens[14]).toEqual value: "", scopes: ["source.csound", "meta.instrument-block.csound", "meta.instrument-declaration.csound"]
 
       tokens = lines[1]
       expect(tokens.length).toBe 2
@@ -91,7 +90,7 @@ describe "language-csound", ->
       """
 
       tokens = lines[0]
-      expect(tokens.length).toBe 14
+      expect(tokens.length).toBe 13
       expect(tokens[0]).toEqual value: "opcode", scopes: ["source.csound", "meta.opcode-definition.csound", "meta.opcode-declaration.csound", "keyword.function.csound"]
       expect(tokens[1]).toEqual value: "/*", scopes: ["source.csound", "meta.opcode-definition.csound", "meta.opcode-declaration.csound", "comment.block.csound", "punctuation.definition.comment.begin.csound"]
       expect(tokens[2]).toEqual value: "*/", scopes: ["source.csound", "meta.opcode-definition.csound", "meta.opcode-declaration.csound", "comment.block.csound", "punctuation.definition.comment.end.csound"]
@@ -105,7 +104,6 @@ describe "language-csound", ->
       expect(tokens[10]).toEqual value: "*/", scopes: ["source.csound", "meta.opcode-definition.csound", "meta.opcode-declaration.csound", "meta.opcode-details.csound", "comment.block.csound", "punctuation.definition.comment.end.csound"]
       expect(tokens[11]).toEqual value: "0", scopes: ["source.csound", "meta.opcode-definition.csound", "meta.opcode-declaration.csound", "meta.opcode-details.csound", "meta.opcode-type-signature.csound", "storage.type.csound"]
       expect(tokens[12]).toEqual value: "//", scopes: ["source.csound", "meta.opcode-definition.csound", "meta.opcode-declaration.csound", "meta.opcode-details.csound", "meta.opcode-type-signature.csound", "comment.line.double-slash.csound", "punctuation.definition.comment.csound"]
-      expect(tokens[13]).toEqual value: "", scopes: ["source.csound", "meta.opcode-definition.csound", "meta.opcode-declaration.csound"]
 
       tokens = lines[1]
       expect(tokens.length).toBe 2
@@ -184,14 +182,13 @@ describe "language-csound", ->
         cters"
       """
       tokens = lines[0]
-      expect(tokens.length).toBe 7
+      expect(tokens.length).toBe 6
       expect(tokens[0]).toEqual value: '"', scopes: ["source.csound", "string.quoted.csound", "punctuation.definition.string.begin.csound"]
       expect(tokens[1]).toEqual value: "chara", scopes: ["source.csound", "string.quoted.csound"]
       expect(tokens[2]).toEqual value: "\\", scopes: ["source.csound", "string.quoted.csound", "constant.character.escape.line-continuation.csound"]
       expect(tokens[3]).toEqual value: " ", scopes: ["source.csound", "string.quoted.csound"]
       expect(tokens[4]).toEqual value: ";", scopes: ["source.csound", "string.quoted.csound", "comment.line.semicolon.csound", "punctuation.definition.comment.csound"]
       expect(tokens[5]).toEqual value: "comment", scopes: ["source.csound", "string.quoted.csound", "comment.line.semicolon.csound"]
-      expect(tokens[6]).toEqual value: "", scopes: ["source.csound", "string.quoted.csound"]
       tokens = lines[1]
       expect(tokens.length).toBe 2
       expect(tokens[0]).toEqual value: "cters", scopes: ["source.csound", "string.quoted.csound"]
@@ -385,14 +382,13 @@ describe "language-csound", ->
     it "tokenizes include directives", ->
       for character in ['"', "|"]
         {tokens} = grammar.tokenizeLine "#include/**/#{character}file.udo#{character}"
-        expect(tokens.length).toBe 7
+        expect(tokens.length).toBe 6
         expect(tokens[0]).toEqual value: "#include", scopes: ["source.csound", "keyword.include.preprocessor.csound"]
         expect(tokens[1]).toEqual value: "/*", scopes: ["source.csound", "comment.block.csound", "punctuation.definition.comment.begin.csound"]
         expect(tokens[2]).toEqual value: "*/", scopes: ["source.csound", "comment.block.csound", "punctuation.definition.comment.end.csound"]
         expect(tokens[3]).toEqual value: character, scopes: ["source.csound", "string.include.csound", "punctuation.definition.string.begin.csound"]
         expect(tokens[4]).toEqual value: "file.udo", scopes: ["source.csound", "string.include.csound"]
         expect(tokens[5]).toEqual value: character, scopes: ["source.csound", "string.include.csound", "punctuation.definition.string.end.csound"]
-        expect(tokens[6]).toEqual value: "", scopes: ["source.csound"]
 
     it "tokenizes object-like macro definitions", ->
       lines = grammar.tokenizeLines """
@@ -492,11 +488,10 @@ describe "language-csound", ->
       lines = grammar.tokenizeLines(preprocessorDirectives.join " MACRO\n")
       for i in [0...lines.length - 1]
         tokens = lines[i]
-        expect(tokens.length).toBe 4
+        expect(tokens.length).toBe 3
         expect(tokens[0]).toEqual value: preprocessorDirectives[i], scopes: ["source.csound", "keyword.preprocessor.csound"]
         expect(tokens[1]).toEqual value: " ", scopes: ["source.csound"]
         expect(tokens[2]).toEqual value: "MACRO", scopes: ["source.csound", "entity.name.function.preprocessor.csound"]
-        expect(tokens[3]).toEqual value: "", scopes: ["source.csound"]
 
     it "tokenizes other preprocessor directives", ->
       preprocessorDirectives = [
@@ -569,17 +564,15 @@ describe "language-csound", ->
         n mark
       """
       tokens = lines[0]
-      expect(tokens.length).toBe 4
+      expect(tokens.length).toBe 3
       expect(tokens[0]).toEqual value: "m", scopes: ["source.csound-score", "keyword.mark.preprocessor.csound-score"]
       expect(tokens[1]).toEqual value: " ", scopes: ["source.csound-score"]
       expect(tokens[2]).toEqual value: "mark", scopes: ["source.csound-score", "entity.name.label.csound-score"]
-      expect(tokens[3]).toEqual value: "", scopes: ["source.csound-score"]
       tokens = lines[1]
-      expect(tokens.length).toBe 4
+      expect(tokens.length).toBe 3
       expect(tokens[0]).toEqual value: "n", scopes: ["source.csound-score", "keyword.repeat-mark.preprocessor.csound-score"]
       expect(tokens[1]).toEqual value: " ", scopes: ["source.csound-score"]
       expect(tokens[2]).toEqual value: "mark", scopes: ["source.csound-score", "entity.name.label.csound-score"]
-      expect(tokens[3]).toEqual value: "", scopes: ["source.csound-score"]
 
     it "tokenizes repeat section statements", ->
       {tokens} = grammar.tokenizeLine "r 1 MACRO\n"
@@ -641,13 +634,12 @@ describe "language-csound", ->
         }
       """
       tokens = lines[0]
-      expect(tokens.length).toBe 6
+      expect(tokens.length).toBe 5
       expect(tokens[0]).toEqual value: "{", scopes: ["source.csound-score", "meta.braced-loop.csound-score", "punctuation.braced-loop.begin.csound-score"]
       expect(tokens[1]).toEqual value: " ", scopes: ["source.csound-score", "meta.braced-loop.csound-score", "meta.braced-loop-details.csound-score"]
       expect(tokens[2]).toEqual value: "10", scopes: ["source.csound-score", "meta.braced-loop.csound-score", "meta.braced-loop-details.csound-score", "constant.numeric.integer.decimal.csound-score"]
       expect(tokens[3]).toEqual value: " ", scopes: ["source.csound-score", "meta.braced-loop.csound-score", "meta.braced-loop-details.csound-score"]
       expect(tokens[4]).toEqual value: "I", scopes: ["source.csound-score", "meta.braced-loop.csound-score", "meta.braced-loop-details.csound-score", "entity.name.function.preprocessor.csound-score"]
-      expect(tokens[5]).toEqual value: "", scopes: ["source.csound-score", "meta.braced-loop.csound-score"]
       tokens = lines[1]
       expect(tokens.length).toBe 1
       expect(tokens[0]).toEqual value: "}", scopes: ["source.csound-score", "meta.braced-loop.csound-score", "punctuation.braced-loop.end.csound-score"]
@@ -657,13 +649,12 @@ describe "language-csound", ->
         }
       """
       tokens = lines[0]
-      expect(tokens.length).toBe 6
+      expect(tokens.length).toBe 5
       expect(tokens[0]).toEqual value: "{", scopes: ["source.csound-score", "meta.braced-loop.csound-score", "punctuation.braced-loop.begin.csound-score"]
       expect(tokens[1]).toEqual value: " ", scopes: ["source.csound-score", "meta.braced-loop.csound-score", "meta.braced-loop-details.csound-score"]
       expect(tokens[2]).toEqual value: "3", scopes: ["source.csound-score", "meta.braced-loop.csound-score", "meta.braced-loop-details.csound-score", "constant.numeric.integer.decimal.csound-score"]
       expect(tokens[3]).toEqual value: " ", scopes: ["source.csound-score", "meta.braced-loop.csound-score", "meta.braced-loop-details.csound-score"]
       expect(tokens[4]).toEqual value: "$FOO", scopes: ["source.csound-score", "meta.braced-loop.csound-score", "meta.braced-loop-details.csound-score", "invalid.illegal.csound-score"]
-      expect(tokens[5]).toEqual value: "", scopes: ["source.csound-score", "meta.braced-loop.csound-score"]
       tokens = lines[1]
       expect(tokens.length).toBe 1
       expect(tokens[0]).toEqual value: "}", scopes: ["source.csound-score", "meta.braced-loop.csound-score", "punctuation.braced-loop.end.csound-score"]


### PR DESCRIPTION
This PR replaces all `\\n` end matches with `$`. The two are nearly identical, with the only difference being that `$` does not create a zero-width match at the end of the line. In addition, since `$` is a zero-width match, that also means the lookaheads are no longer necessary :).  These changes are mainly required due to atom/first-mate#100, as newlines are no longer added to the last line of the file. Therefore, this change is simply a backwards-compatible change to ensure that language-csound continues working as before on Atom 1.22+.

/cc @Ingramz

Refs atom/atom#15729