### PR TITLE
Update for compatibility with Atom 1.23

### DIFF
--- a/lib/csound-pattern.coffee
+++ b/lib/csound-pattern.coffee
@@ -21,7 +21,7 @@ class CsoundPattern extends Pattern
           for change in event.changes
             # bufferRangeForScopeAtPosition is a private method of TextEditor
             # (https://github.com/atom/atom/search?q=bufferRangeForScopeAtPosition+path%3Asrc+filename%3Atext-editor.coffee)
-            range = editor.bufferRangeForScopeAtPosition('entity.name.function.opcode.csound', event.oldRange.start)
+            range = editor.bufferRangeForScopeAtPosition('entity.name.function.opcode.csound', change.oldRange.start)
 
             if range
               index = userDefinedOpcodes.indexOf(editor.getTextInBufferRange(range))

--- a/lib/csound-pattern.coffee
+++ b/lib/csound-pattern.coffee
@@ -17,21 +17,22 @@ class CsoundPattern extends Pattern
       @userDefinedOpcodesByWorkspaceIDs[workspace.id] = userDefinedOpcodes
 
       @subscriptions.add workspace.observeTextEditors((editor) =>
-        @subscriptions.add editor.buffer.onWillChange((event) ->
-          # bufferRangeForScopeAtPosition is a private method of TextEditor
-          # (https://github.com/atom/atom/search?q=bufferRangeForScopeAtPosition+path%3Asrc+filename%3Atext-editor.coffee)
-          range = editor.bufferRangeForScopeAtPosition('entity.name.function.opcode.csound', event.oldRange.start)
+        @subscriptions.add editor.buffer.onDidChangeText((event) ->
+          for change in event.changes
+            # bufferRangeForScopeAtPosition is a private method of TextEditor
+            # (https://github.com/atom/atom/search?q=bufferRangeForScopeAtPosition+path%3Asrc+filename%3Atext-editor.coffee)
+            range = editor.bufferRangeForScopeAtPosition('entity.name.function.opcode.csound', event.oldRange.start)
 
-          if range
-            index = userDefinedOpcodes.indexOf(editor.getTextInBufferRange(range))
-            if index >= 0
-              userDefinedOpcodes.splice(index, 1)
-              # tokenizedBuffer is a private property of TextEditor
-              # (https://github.com/atom/atom/search?q=tokenizedBuffer+path%3Asrc+filename%3Atext-editor.coffee)
-              # that returns an instance of the private class TokenizedBuffer
-              # (https://github.com/atom/atom/search?q=invalidateRow+path%3Asrc+filename%3Atokenized-buffer.coffee)
-              for row in [0...editor.getLineCount()] when !editor.isBufferRowCommented(row)
-                editor.tokenizedBuffer.invalidateRow(row)
+            if range
+              index = userDefinedOpcodes.indexOf(editor.getTextInBufferRange(range))
+              if index >= 0
+                userDefinedOpcodes.splice(index, 1)
+                # tokenizedBuffer is a private property of TextEditor
+                # (https://github.com/atom/atom/search?q=tokenizedBuffer+path%3Asrc+filename%3Atext-editor.coffee)
+                # that returns an instance of the private class TokenizedBuffer
+                # (https://github.com/atom/atom/search?q=invalidateRow+path%3Asrc+filename%3Atokenized-buffer.coffee)
+                for row in [0...editor.getLineCount()] when !editor.isBufferRowCommented(row)
+                  editor.tokenizedBuffer.invalidateRow(row)
         )
       )
 


### PR DESCRIPTION
:wave: @nwhetsell, Thanks for creating this package!

In Atom 1.23, we'll be making a breaking change to the behavior of the `TextBuffer.onWillChange` method: an event object will no longer be passed to the method's callback. For a description of the change, see atom/text-buffer#270.

### The Breaking API Change

The reason that we're making this breaking change is that the `.onWillChange` method has been a source of performance problems in Atom when making many simultaneous changes to a buffer, for example when typing with many cursors. The problem is that the method used to get called once for each *individual* buffer change, which would result in a lot of computation per keystroke.

Now, we only call the `onWillChange` callbacks once for each buffer *transaction* (a grouping of changes that can be undone and redone as an atomic unit). Because of this, there is no longer a single `oldRange` and `newRange` associated with the call.

### The Fix to Your Code

You should be able to simply use the `TextBuffer.onDidChangeText` method instead. This method calls its callback at the *end* of a transaction instead of the beginning, so it is able to provide information about each change that occurred.

The callback is still guaranteed to be called *before* the next frame is rendered, so in your case, the syntax highlighting should still be updated in time.

I apologize to you for not providing backwards-compatibility in this case. Because there were so few (~4) packages that use the `.onWillChange` method, we chose to just reach out to package maintainers individually, rather than trying to somehow keep old code working.

